### PR TITLE
Add vetiver to "Deployment through cloud/server"

### DIFF
--- a/ModelDeployment.md
+++ b/ModelDeployment.md
@@ -143,6 +143,11 @@ environments:
 - The `r pkg("tfdeploy")` package provides functions to
   run a local test server that supports the same REST API as CloudML
   and [RStudio Connect](https://www.rstudio.com/products/connect/).
+- The `r pkg("vetiver")` package provides tooling to version, share,
+  deploy, and monitor a trained model. Functions handle both recording 
+  and checking the model's input data prototype, and predicting from a 
+  remote API endpoint. This package is extensible, with generics to
+  support many kinds of models.
 - The `r pkg("domino")` package provides R interface to
   [Domino](https://www.dominodatalab.com/) CLI, a service that makes
   it easy to run your code on scalable hardware, with integrated


### PR DESCRIPTION
Thank you so much for maintaining this CRAN Task View! 🙌 

I would like to propose adding the [vetiver](https://vetiver.tidymodels.org/) package. 

> The goal of vetiver is to provide fluent tooling to version, share, deploy, and monitor a trained model. Functions handle both recording and checking the model’s input data prototype, and predicting from a remote API endpoint. The vetiver package is extensible, with generics that can support many kinds of models.

Let me know if you have any questions! I placed vetiver where I thought it probably makes the most sense, but feel free to adjust that.