### PR TITLE
Remove 'yhatr' package mention from documentation

### DIFF
--- a/ModelDeployment.md
+++ b/ModelDeployment.md
@@ -126,8 +126,6 @@ Many deployment environments are based on cloud/server. The following
 packages provides functionalities to deploy models in those types of
 environments:
 
-- The `r pkg("yhatr")` package allows to deploy, maintain,
-  and invoke models via the [Yhat](https://www.yhat.com) REST API.
 - The `r pkg("cloudml")` package provides functionality to
   easily deploy models to [Google Cloud ML Engine](https://cloud.google.com/ml-engine/).
 - The `r pkg("tfdeploy")` package provides functions to


### PR DESCRIPTION
Removed reference to the 'yhatr' package for model deployment.

The yhat org ( https://github.com/yhat ) with the [package under it](https://github.com/yhat/yhatr) was placed into archive mode 

> This organization was marked as archived by an administrator on Mar 22, 2026. It is no longer maintained. 

Close #15