### PR TITLE
Remove `pmmlTransformations` package details

### DIFF
--- a/ModelDeployment.md
+++ b/ModelDeployment.md
@@ -3,7 +3,7 @@ name: ModelDeployment
 topic: Model Deployment with R
 maintainer: Yuan Tang, James Joseph Balamuta
 email: terrytangyuan@gmail.com
-version: 2022-08-24
+version: 2026-04-24
 source: https://github.com/cran-task-views/ModelDeployment
 ---
 
@@ -51,11 +51,6 @@ packages are built based on different model format.
   applications. The following packages are based on PMML:
   - The `r pkg("pmml")` package provides the main
     interface to PMML.
-  - The `r pkg("pmmlTransformations")` package allows
-    for data to be transformed before using it to construct models.
-    Builds structures to allow functions in the PMML package to
-    output transformation details in addition to the model in the
-    resulting PMML file.
   - The `r pkg("arules")` package provides the
     infrastructure for representing, manipulating and analyzing
     transaction data and patterns (frequent itemsets and association


### PR DESCRIPTION
Removed details about `pmmlTransformations` package as the package was last updated over 7 years ago. There is no GitHub-facing repo for it and the webpage listed in `DESCRIPTION` (<https://www.softwareag.com/zementis>) was removed from the website. Close #17. 

<details>
<summary> `pmmlTransformations` - R CMD Check Messages </summary>
```r
Version: 1.3.3
Check: CRAN incoming feasibility
Result: NOTE 
  Maintainer: ‘Dmitriy Bolotov <rpmmlsupport@softwareag.com>’
  
  No Authors@R field in DESCRIPTION.
  Please add one, modifying
    Authors@R: c(person(given = "Tridivesh",
                        family = "Jena",
                        role = "aut"),
                 person(given = c("Wen", "Ching"),
                        family = "Lin",
                        role = "aut"),
                 person(given = "Dmitriy",
                        family = "Bolotov",
                        role = c("aut", "cre"),
                        email = "rpmmlsupport@softwareag.com"))
  as necessary.
Flavors: [r-devel-linux-x86_64-debian-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-clang/pmmlTransformations-00check.html), [r-devel-linux-x86_64-debian-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-gcc/pmmlTransformations-00check.html)

Version: 1.3.3
Check: Rd cross-references
Result: NOTE 
  Unknown package ‘pmml’ in Rd xrefs
Flavors: [r-devel-linux-x86_64-debian-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-clang/pmmlTransformations-00check.html), [r-devel-linux-x86_64-debian-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-gcc/pmmlTransformations-00check.html), [r-devel-linux-x86_64-fedora-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-clang/pmmlTransformations-00check.html), [r-devel-linux-x86_64-fedora-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-gcc/pmmlTransformations-00check.html), [r-patched-linux-x86_64](https://www.r-project.org/nosvn/R.check/r-patched-linux-x86_64/pmmlTransformations-00check.html), [r-release-linux-x86_64](https://www.r-project.org/nosvn/R.check/r-release-linux-x86_64/pmmlTransformations-00check.html)

Version: 1.3.3
Check: examples
Result: ERROR 
  Running examples in ‘pmmlTransformations-Ex.R’ failed
  The error most likely occurred in:
  
  > base::assign(".ptime", proc.time(), pos = "CheckExEnv")
  > ### Name: DiscretizeXform
  > ### Title: Discretizes a continuous variable to a discrete one as indicated
  > ###   by interval mappings. This is in accordance to the PMML element:
  > ###   *Discretize*
  > ### Aliases: DiscretizeXform
  > ### Keywords: manip
  > 
  > ### ** Examples
  > 
  > # Load the pmmlTransformations package
  >     library(pmmlTransformations)
  >     library(pmml)
  Error in library(pmml) : there is no package called ‘pmml’
  Execution halted
Flavors: [r-devel-linux-x86_64-debian-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-clang/pmmlTransformations-00check.html), [r-devel-linux-x86_64-debian-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-gcc/pmmlTransformations-00check.html), [r-patched-linux-x86_64](https://www.r-project.org/nosvn/R.check/r-patched-linux-x86_64/pmmlTransformations-00check.html), [r-release-linux-x86_64](https://www.r-project.org/nosvn/R.check/r-release-linux-x86_64/pmmlTransformations-00check.html)

Version: 1.3.3
Check: re-building of vignette outputs
Result: ERROR 
  Error(s) in re-building vignettes:
    ...
  --- re-building ‘FunctionXform.Rmd’ using rmarkdown
  
  Quitting from FunctionXform.Rmd:30-34 [unnamed-chunk-2]
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  <error/rlang_error>
  Error in `library()`:
  ! there is no package called 'pmml'
  ---
  Backtrace:
      ▆
   1. └─base::library(pmml)
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  
  Error: processing vignette 'FunctionXform.Rmd' failed with diagnostics:
  there is no package called 'pmml'
  --- failed re-building ‘FunctionXform.Rmd’
  
  SUMMARY: processing the following file failed:
    ‘FunctionXform.Rmd’
  
  Error: Vignette re-building failed.
  Execution halted
Flavors: [r-devel-linux-x86_64-debian-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-clang/pmmlTransformations-00check.html), [r-devel-linux-x86_64-debian-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-gcc/pmmlTransformations-00check.html), [r-patched-linux-x86_64](https://www.r-project.org/nosvn/R.check/r-patched-linux-x86_64/pmmlTransformations-00check.html), [r-release-linux-x86_64](https://www.r-project.org/nosvn/R.check/r-release-linux-x86_64/pmmlTransformations-00check.html)

Version: 1.3.3
Check: examples
Result: ERROR 
  Running examples in ‘pmmlTransformations-Ex.R’ failed
  The error most likely occurred in:
  
  > ### Name: DiscretizeXform
  > ### Title: Discretizes a continuous variable to a discrete one as indicated
  > ###   by interval mappings. This is in accordance to the PMML element:
  > ###   *Discretize*
  > ### Aliases: DiscretizeXform
  > ### Keywords: manip
  > 
  > ### ** Examples
  > 
  > # Load the pmmlTransformations package
  >     library(pmmlTransformations)
  >     library(pmml)
  Error in library(pmml) : there is no package called ‘pmml’
  Execution halted
Flavors: [r-devel-linux-x86_64-fedora-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-clang/pmmlTransformations-00check.html), [r-devel-linux-x86_64-fedora-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-gcc/pmmlTransformations-00check.html)

Version: 1.3.3
Check: re-building of vignette outputs
Result: ERROR 
  Error(s) in re-building vignettes:
  --- re-building ‘FunctionXform.Rmd’ using rmarkdown
  
  Quitting from FunctionXform.Rmd:30-34 [unnamed-chunk-2]
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  <error/rlang_error>
  Error in `library()`:
  ! there is no package called 'pmml'
  ---
  Backtrace:
      ▆
   1. └─base::library(pmml)
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  
  Error: processing vignette 'FunctionXform.Rmd' failed with diagnostics:
  there is no package called 'pmml'
  --- failed re-building ‘FunctionXform.Rmd’
  
  SUMMARY: processing the following file failed:
    ‘FunctionXform.Rmd’
  
  Error: Vignette re-building failed.
  Execution halted
Flavors: [r-devel-linux-x86_64-fedora-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-clang/pmmlTransformations-00check.html), [r-devel-linux-x86_64-fedora-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-gcc/pmmlTransformations-00check.html)
```
</details>